### PR TITLE
Update markup to be more accessiblity friendly

### DIFF
--- a/app/styles/app.sass
+++ b/app/styles/app.sass
@@ -73,6 +73,9 @@ p.large
 p.huge
   font-size: 28px
 
+h4.ui.header
+  text-transform: uppercase
+
 .ui.header
   font-family: 'Montserrat', sans-serif
   color: $dark-gray

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -3,7 +3,7 @@
 <div class="ui grid container page-grid">
   <div class="centered row">
     <div class="fourteen wide center aligned column">
-      <div class="ui primary large header">OUR MISSION</div>
+      <h4 class="ui primary large header">Our Missio</h4>
       <p class="large">
         Our mission is to help you reach your fitness and health goals.
         We are focused on providing the best possible environment for people of all fitness levels to help them live a healthier lifestyle.
@@ -15,7 +15,7 @@
 
   <div class="centered row">
     <div class="fourteen wide center aligned column">
-      <div class="ui primary large header">OUR COACHES</div>
+      <h4 class="ui primary large header">Our Coaches</h4>
 
       <p class="large">
         We have knowledgeable and experienced coaches who know how to drive results.
@@ -46,7 +46,7 @@
 
   <div class="centered row">
     <div class="fourteen wide center aligned column">
-      <div class="ui primary large header">OUR COMMUNITY</div>
+      <h4 class="ui primary large header">Our Community</h4>
       <p class="large">
         At Elliott Bay CrossFit, you will be surrounded by fun, dedicated, and compassionate athletes who are all on the same fitness journey.
         Our community cultivates an environment of motivation and accountability that will push you everyday to get better.

--- a/app/templates/components/wod-item.hbs
+++ b/app/templates/components/wod-item.hbs
@@ -44,12 +44,12 @@
     <div class="ui huge header">{{wod.prettyDate}}</div>
 
     {{#if wod.strength}}
-      <div class="ui large header orange">STRENGTH/SKILL</div>
+      <h4 class="ui large header orange">Strength/Skill</h4>
       <div class="pre">{{{wod.strength}}}</div>
     {{/if}}
 
     {{#if wod.conditioning}}
-      <div class="ui large header orange">CONDITIONING</div>
+      <h4 class="ui large header orange">Conditioning</h4>
       <div class="pre">{{{wod.conditioning}}}</div>
     {{/if}}
   </div>
@@ -72,7 +72,7 @@
     <div class="ui one column stackable centered grid bottom-padding">
 
       <div class="column">
-        <div class="ui large header orange">ABOUT THIS WORKOUT</div>
+        <h4 class="ui large header orange">About This Workout</h4>
         <div class="pre">{{{wod.description}}}</div>
       </div>
 

--- a/app/templates/getting-started.hbs
+++ b/app/templates/getting-started.hbs
@@ -4,9 +4,9 @@
 
   <div class="row">
     <div class="center aligned sixteen wide column">
-      <div class="ui large header primary">
-        THE SPORT OF FITNESS
-      </div>
+      <h4 class="ui large header primary">
+        The Sport of Fitness
+      </h4>
     </div>
     <div class="center aligned sixteen wide column">
       <p class="large">
@@ -31,9 +31,9 @@
 
   <div class="row">
     <div class="sixteen wide center aligned column">
-      <div class="ui large header primary">
-          NEW TO CROSSFIT?
-      </div>
+      <h4 class="ui large header primary">
+        New to Crossfit?
+      </h4>
     </div>
     <div class="sixteen wide center aligned column">
       <p class="large">
@@ -63,9 +63,9 @@
 
   <div class="row">
     <div class="center aligned sixteen wide column">
-      <div class="ui large header primary">
-        HOW TO SIGN UP
-      </div>
+      <h4 class="ui large header primary">
+        How to Sign Up
+      </h4>
     </div>
     <div class="center aligned sixteen wide column">
       <p class="large">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -40,12 +40,12 @@
     <div class="five wide computer seven wide tablet column">
       <div class="ui header huge">{{wod.prettyDate}}</div>
       {{#if wod.strength}}
-        <div class="ui large header orange">STRENGTH/SKILL</div>
+        <h4 class="ui large header orange">Strength/Skill</h4>
         <div class="home-pre">{{wod.strength}}</div>
       {{/if}}
 
       {{#if wod.conditioning}}
-        <div class="ui large header orange">CONDITIONING</div>
+        <h4 class="ui large header orange">Conditioning</h4>
         <div class="home-pre">{{wod.conditioning}}</div>
       {{/if}}
 
@@ -66,7 +66,7 @@
 
     <div class="four wide computer thirteen wide tablet center aligned column">
       <div class="comminity-image"></div>
-      <div class="ui large header">COMMUNITY</div>
+      <h4 class="ui large header">Community</h4>
 
       <p class="">
         Elliott Bay CrossFit is a community of fun, dedicated, and compassionate athletes.
@@ -82,7 +82,7 @@
     <div class="four wide computer thirteen wide tablet center aligned column">
       <div class="programming-image"></div>
 
-      <div class="ui large header">PROGRAMMING</div>
+      <h4 class="ui large header">Programming</h4>
 
       <p class="">
         Our mission is to help you reach your goals.
@@ -98,7 +98,7 @@
     <div class="four wide computer thirteen wide tablet center aligned column">
       <div class="results-image"></div>
 
-      <div class="ui large header">RESULTS</div>
+      <h4 class="ui large header">Results</h4>
 
       <p class="">
         CrossFit is a strength and conditioning fitness program that has been proven effective around the world.

--- a/app/templates/pricing.hbs
+++ b/app/templates/pricing.hbs
@@ -176,9 +176,9 @@
   <hr>
 
   <div class="fourteen wide column">
-    <div class="ui large header primary">
-      CANCELLATION, REFUND & PRIVACY POLICY
-    </div>
+    <h4 class="ui large header primary">
+      Cancellation, Refund &amp; Privacy Policy
+    </h4>
     <p class="large">
       You can cancel at anytime directly through Front Desk or by contacting us at info@elliottbaycrossfit.com.
       <br>

--- a/app/templates/pricing/privacy.hbs
+++ b/app/templates/pricing/privacy.hbs
@@ -4,9 +4,9 @@
 
   <div class="ui segment">
 
-    <div class="ui large header primary">
-      PRIVACY POLICY
-    </div>
+    <h4 class="ui large header primary">
+      Privacy Policy
+    </h4>
 
     <div class="ui medium header primary">
       TO OUR INDIVIDUAL CLIENTS


### PR DESCRIPTION
Untested (I'm not very familiar with Ember).

These changes are the low-hanging fruit for assisting disabled people.  Those that require keyboard navigation (motor ability or blindness) will typically navigate by jumping between headers (`h1` - `h6`), allowing them to quickly glean information without reading everything.

Change most strings from CAPITALIZED to normal cased words.  When screen readers see these, they tend to assume they're acronyms and will spell out each letter instead of just stating the word as desired.